### PR TITLE
Add rust like highlighting to proc macro

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -58,3 +58,6 @@
 
 (comment) @comment @spell
 
+(annotation
+  (id) @function.macro)
+


### PR DESCRIPTION
Proc macros like `#[precedence(level = "1")]` were lacking syntax highlighting. This PR adds it.