### PR TITLE
Change the color for non terminal symbols to better fit their use

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -30,16 +30,16 @@
 
 (bare_symbol
   (macro 
-    ((macro_id) @function)))
+    ((macro_id) @function.macro)))
 
 (bare_symbol
-  (identifier) @function)
+  (identifier) @constant)
 
 (nonterminal_name
-  (macro_id) @function)
+  (macro_id) @function.macro)
 
 (nonterminal_name
-  (identifier) @function)
+  (identifier) @constant)
 
 (nonterminal
   (type_ref) @type)


### PR DESCRIPTION
- Using `@constant` for basic non terminal
- using `@function.macro` for macro non terminal

This PR is only tweaking already existing colors so it could be controversial.