### PR TITLE
Use rust parser to highlight use statements and actions

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,8 @@
+((normal_action) @injection.content 
+  (#set! injection.language "rust"))
+
+((failible_action) @injection.content 
+  (#set! injection.language "rust"))
+
+((use) @injection.content
+  (#set! injection.language "rust"))


### PR DESCRIPTION
Nvim allows using other Tree-sitter parsers to highlight regions of code. This PR use this feature to highlight parts that are meant to be pure rust code.