### PR TITLE
fix: mark `$.comment` as an extra token

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -144,7 +144,7 @@ module.exports = grammar({
 			choice(
 				/[^xu]/,
 				/u[0-9a-fA-F]{4}/,
-				/u{[0-9a-fA-F]+}/,
+				/u\{[0-9a-fA-F]+\}/,
 				/x[0-9a-fA-F]{2}/
 			)
 		)),

--- a/grammar.js
+++ b/grammar.js
@@ -22,6 +22,8 @@ module.exports = grammar({
 		$.failible_action,
 	],
 
+	extras: $ => [/\s/, $.comment],
+
 	rules: {
 		source_file: $ => seq(
 			repeat($._use),
@@ -181,7 +183,6 @@ module.exports = grammar({
 
 		grammar_item: $ => choice(
 			$._use,
-			$.comment,
 			$.extern_token,
 			$.match_token,
 			$.nonterminal,


### PR DESCRIPTION
fixes: #7 

## Changes:

- mark `$.comment` as an extra token, so that it can occur between any tokens.
- fix regex literal escape

## Preview:

![image](https://github.com/traxys/tree-sitter-lalrpop/assets/72962900/6d92fa4e-23a7-421e-862c-aff9b8d974ce)
